### PR TITLE
Add initial backend test suite

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"No tests yet\"",
+    "test": "jest",
     "start": "node index.js"
   },
   "keywords": [],
@@ -17,5 +17,9 @@
     "express": "^5.1.0",
     "firebase-admin": "^13.4.0",
     "socket.io": "^4.8.1"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^7.1.1"
   }
 }

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -1,0 +1,19 @@
+const request = require('supertest');
+const { app, server } = require('../server');
+
+afterAll(() => {
+  server.close();
+});
+
+describe('API routes', () => {
+  it('creates and starts a game via API', async () => {
+    const createRes = await request(app).post('/api/game/create');
+    expect(createRes.status).toBe(200);
+    const { gameId } = createRes.body;
+    expect(gameId).toMatch(/game_/);
+
+    const startRes = await request(app).post(`/api/game/${gameId}/start`);
+    expect(startRes.status).toBe(200);
+    expect(startRes.body).toHaveProperty('quarter', 1);
+  });
+});

--- a/backend/tests/firestoreService.test.js
+++ b/backend/tests/firestoreService.test.js
@@ -1,0 +1,15 @@
+const firestore = require('../services/firestoreService');
+
+describe('firestoreService', () => {
+  it('creates and starts a game, saving actions', async () => {
+    const { id } = await firestore.createGame();
+    expect(id).toMatch(/game_/);
+
+    const state = await firestore.startGame(id);
+    expect(state).toHaveProperty('quarter', 1);
+
+    await firestore.savePlayerAction(id, 'player1', { type: 'test' });
+    const newState = await firestore.getGameState(id);
+    expect(newState.quarter).toBe(2);
+  });
+});

--- a/backend/tests/simulation.test.js
+++ b/backend/tests/simulation.test.js
@@ -1,0 +1,12 @@
+const Simulation = require('../simulation/Simulation');
+
+describe('Simulation', () => {
+  it('runs a quarter and updates economic metrics', () => {
+    const sim = new Simulation();
+    const prevQuarter = sim.state.quarter;
+    sim.runQuarter();
+    expect(sim.state.quarter).toBe(prevQuarter + 1);
+    expect(sim.state.economy.gdp).toBeGreaterThan(1000);
+    expect(sim.state.economy.purchasingPower).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest and Supertest for backend testing
- implement unit tests for Simulation and Firestore service
- add API route test

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684e2e66dd4c83238721325d9efe35b7