### PR TITLE
Implement Phase 3 basic UI

### DIFF
--- a/frontend/src/views/GM/GMView.jsx
+++ b/frontend/src/views/GM/GMView.jsx
@@ -1,8 +1,62 @@
-const GMView = () => (
-  <div>
-    <h1>Game Master View</h1>
-    <p>Coming soon...</p>
-  </div>
-);
+import React, { useEffect, useState } from 'react';
+import { useSocket } from '../../context/SocketProvider';
+import GMDashboard from './components/GMDashboard';
+import GlobalLevers from './components/GlobalLevers';
+import ShockEventControl from './components/ShockEventControl';
+import GameControls from './components/GameControls';
+import PlayerStatus from './components/PlayerStatus';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+const GAME_ID = 'game_1';
+
+const GMView = () => {
+  const socket = useSocket();
+  const [state, setState] = useState(null);
+  const [submitted, setSubmitted] = useState([]);
+  const [levers, setLevers] = useState({ taxRate: 20 });
+
+  useEffect(() => {
+    if (!socket) return;
+    socket.emit('joinRoom', { gameId: GAME_ID });
+    const handleQuarter = (data) => setState(data);
+    const handleDecision = ({ playerId }) => setSubmitted((s) => [...s, playerId]);
+    socket.on('newQuarter', handleQuarter);
+    socket.on('decisionReceived', handleDecision);
+    return () => {
+      socket.off('newQuarter', handleQuarter);
+      socket.off('decisionReceived', handleDecision);
+    };
+  }, [socket]);
+
+  useEffect(() => {
+    fetch(`${API_URL}/api/game/${GAME_ID}/state`)
+      .then((res) => res.json())
+      .then(setState)
+      .catch(() => {});
+  }, []);
+
+  const start = async () => {
+    await fetch(`${API_URL}/api/game/${GAME_ID}/start`, { method: 'POST' });
+  };
+
+  const triggerShock = async (command) => {
+    await fetch(`${API_URL}/api/gm/action`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ gameId: GAME_ID, command })
+    });
+  };
+
+  return (
+    <div>
+      <h1>Game Master View</h1>
+      <GameControls start={start} />
+      <GlobalLevers levers={levers} onChange={setLevers} />
+      <ShockEventControl trigger={triggerShock} />
+      <PlayerStatus submitted={submitted} />
+      <GMDashboard companies={state?.companies || []} />
+    </div>
+  );
+};
 
 export default GMView;

--- a/frontend/src/views/GM/components/GMDashboard.jsx
+++ b/frontend/src/views/GM/components/GMDashboard.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+const GMDashboard = ({ companies = [] }) => (
+  <div>
+    <h2>Companies</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Cash</th>
+          <th>Revenue</th>
+        </tr>
+      </thead>
+      <tbody>
+        {companies.map((c, i) => (
+          <tr key={i}>
+            <td>{c.name}</td>
+            <td>{c.cash}</td>
+            <td>{c.revenue}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+export default GMDashboard;

--- a/frontend/src/views/GM/components/GameControls.jsx
+++ b/frontend/src/views/GM/components/GameControls.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const GameControls = ({ start }) => (
+  <div>
+    <h3>Game Controls</h3>
+    <button type="button" onClick={start}>Start Game</button>
+  </div>
+);
+
+export default GameControls;

--- a/frontend/src/views/GM/components/GlobalLevers.jsx
+++ b/frontend/src/views/GM/components/GlobalLevers.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const GlobalLevers = ({ onChange, levers }) => (
+  <div>
+    <h3>Global Levers</h3>
+    <label>
+      Tax Rate: {levers.taxRate}%
+      <input type="range" min="0" max="100" value={levers.taxRate}
+        onChange={(e) => onChange({ ...levers, taxRate: Number(e.target.value) })}
+      />
+    </label>
+  </div>
+);
+
+export default GlobalLevers;

--- a/frontend/src/views/GM/components/PlayerStatus.jsx
+++ b/frontend/src/views/GM/components/PlayerStatus.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const PlayerStatus = ({ submitted = [] }) => (
+  <div>
+    <h3>Player Status</h3>
+    <ul>
+      {submitted.map((p, i) => (
+        <li key={i}>{p} submitted</li>
+      ))}
+    </ul>
+  </div>
+);
+
+export default PlayerStatus;

--- a/frontend/src/views/GM/components/ShockEventControl.jsx
+++ b/frontend/src/views/GM/components/ShockEventControl.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const ShockEventControl = ({ trigger }) => (
+  <div>
+    <h3>Shock Events</h3>
+    <button type="button" onClick={() => trigger('marketCrash')}>Market Crash</button>
+    <button type="button" onClick={() => trigger('techBreakthrough')}>Tech Breakthrough</button>
+  </div>
+);
+
+export default ShockEventControl;

--- a/frontend/src/views/Observer/ObserverView.jsx
+++ b/frontend/src/views/Observer/ObserverView.jsx
@@ -8,7 +8,7 @@ const ObserverView = () => {
   const socket = useSocket();
   const [state, setState] = useState({ history: [] });
   const [news, setNews] = useState([]);
-  const [gameId, setGameId] = useState('game_1');
+  const [gameId] = useState('game_1');
 
   useEffect(() => {
     if (!socket) return;

--- a/frontend/src/views/Player/PlayerView.jsx
+++ b/frontend/src/views/Player/PlayerView.jsx
@@ -1,8 +1,57 @@
-const PlayerView = () => (
-  <div>
-    <h1>Player View</h1>
-    <p>Coming soon...</p>
-  </div>
-);
+import React, { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { useSocket } from '../../context/SocketProvider';
+import PlayerDashboard from './components/PlayerDashboard';
+import DecisionDeck from './components/DecisionDeck';
+import EmployeeRoster from './components/EmployeeRoster';
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+const PlayerView = () => {
+  const { id: gameId } = useParams();
+  const socket = useSocket();
+  const [state, setState] = useState(null);
+  const [playerId] = useState(() => {
+    const existing = localStorage.getItem('playerId');
+    if (existing) return existing;
+    const pid = `player_${Math.random().toString(36).slice(2, 8)}`;
+    localStorage.setItem('playerId', pid);
+    return pid;
+  });
+
+  useEffect(() => {
+    if (!socket) return;
+    socket.emit('joinRoom', { gameId, playerId });
+    const handleQuarter = (data) => setState(data);
+    socket.on('newQuarter', handleQuarter);
+    return () => {
+      socket.off('newQuarter', handleQuarter);
+    };
+  }, [socket, gameId, playerId]);
+
+  useEffect(() => {
+    fetch(`${API_URL}/api/game/${gameId}/state`)
+      .then((res) => res.json())
+      .then(setState)
+      .catch(() => {});
+  }, [gameId]);
+
+  const submitAction = async (action) => {
+    await fetch(`${API_URL}/api/player/action`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ gameId, playerId, action })
+    });
+  };
+
+  return (
+    <div>
+      <h1>Player View</h1>
+      <PlayerDashboard company={state?.companies?.[0]} />
+      <EmployeeRoster employees={state?.companies?.[0]?.employees} />
+      <DecisionDeck onSubmit={submitAction} />
+    </div>
+  );
+};
 
 export default PlayerView;

--- a/frontend/src/views/Player/components/AIOpportunityCard.jsx
+++ b/frontend/src/views/Player/components/AIOpportunityCard.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const AIOpportunityCard = ({ selected, onSelect }) => (
+  <div onClick={() => onSelect({ type: 'aiOpportunity', adopt: true })} style={{ border: selected ? '2px solid #32b8c6' : '1px solid #ccc', padding: '8px', marginBottom: '8px', cursor: 'pointer' }}>
+    <h4>AI Opportunity</h4>
+    <p>Invest in AI to improve efficiency.</p>
+  </div>
+);
+
+export default AIOpportunityCard;

--- a/frontend/src/views/Player/components/DecisionDeck.jsx
+++ b/frontend/src/views/Player/components/DecisionDeck.jsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import AIOpportunityCard from './AIOpportunityCard';
+import InvestmentCard from './InvestmentCard';
+
+const DecisionDeck = ({ onSubmit }) => {
+  const [selected, setSelected] = useState(null);
+
+  const handleSelect = (action) => setSelected(action);
+
+  const handleSubmit = () => {
+    if (selected) onSubmit(selected);
+  };
+
+  return (
+    <div>
+      <h3>Decisions</h3>
+      <AIOpportunityCard selected={selected?.type === 'aiOpportunity'} onSelect={handleSelect} />
+      <InvestmentCard selected={selected?.type === 'investment'} onSelect={handleSelect} />
+      <button type="button" onClick={handleSubmit} disabled={!selected}>Submit</button>
+    </div>
+  );
+};
+
+export default DecisionDeck;

--- a/frontend/src/views/Player/components/EmployeeRoster.jsx
+++ b/frontend/src/views/Player/components/EmployeeRoster.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+const EmployeeRoster = ({ employees }) => (
+  <div>
+    <h3>Employees</h3>
+    <ul>
+      {employees && employees.length > 0 ? (
+        employees.map((e, i) => (
+          <li key={i}>{e.name} - {e.role}</li>
+        ))
+      ) : (
+        <li>No employees</li>
+      )}
+    </ul>
+  </div>
+);
+
+export default EmployeeRoster;

--- a/frontend/src/views/Player/components/InvestmentCard.jsx
+++ b/frontend/src/views/Player/components/InvestmentCard.jsx
@@ -1,0 +1,17 @@
+import React, { useState } from 'react';
+
+const InvestmentCard = ({ onSelect, selected }) => {
+  const [amount, setAmount] = useState(0);
+  const handleClick = () => {
+    onSelect({ type: 'investment', amount: Number(amount) });
+  };
+  return (
+    <div style={{ border: selected ? '2px solid #32b8c6' : '1px solid #ccc', padding: '8px', marginBottom: '8px' }}>
+      <h4>Investment</h4>
+      <input type="number" value={amount} onChange={(e) => setAmount(e.target.value)} />
+      <button type="button" onClick={handleClick}>Select</button>
+    </div>
+  );
+};
+
+export default InvestmentCard;

--- a/frontend/src/views/Player/components/PlayerDashboard.jsx
+++ b/frontend/src/views/Player/components/PlayerDashboard.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const PlayerDashboard = ({ company }) => {
+  if (!company) return <p>No company data</p>;
+  return (
+    <div>
+      <h2>{company.name}</h2>
+      <p>Cash: {company.cash}</p>
+      <p>Revenue: {company.revenue}</p>
+    </div>
+  );
+};
+
+export default PlayerDashboard;


### PR DESCRIPTION
## Summary
- add player dashboard with decision deck and roster
- implement GM dashboard with levers and controls
- hook up Player and GM views to backend APIs
- fix lint issue in ObserverView

## Testing
- `npm run lint` in `frontend`
- `npm test` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_684e2d46774883239eaa8e920b503965