### PR TITLE
Implement Gemini LLM service

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
+    "@google/generative-ai": "^0.24.1",
     "body-parser": "^2.2.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",

--- a/backend/services/firestoreService.js
+++ b/backend/services/firestoreService.js
@@ -1,4 +1,5 @@
 const Simulation = require('../simulation/Simulation');
+const llm = require('./llmService');
 const games = {};
 let gameCounter = 1;
 
@@ -8,12 +9,23 @@ async function createGame() {
     return { id };
 }
 
-async function startGame(gameId) {
+async function startGame(gameId, playerCount = 3) {
     const game = games[gameId];
     if (!game) throw new Error('Game not found');
     game.status = 'in-progress';
     game.simulation = new Simulation();
     game.state = game.simulation.state;
+    // LLM integration to generate initial companies
+    const ecosystem = await llm.generateEcosystem(playerCount);
+    game.state.companies = [];
+    for (const biz of ecosystem) {
+        const details = await llm.generateCompanyDetails(biz.type || biz.name);
+        game.state.companies.push({
+            type: biz.type,
+            name: biz.name,
+            details
+        });
+    }
     return game.state;
 }
 
@@ -28,7 +40,12 @@ async function savePlayerAction(gameId, playerId, action) {
     if (!game) throw new Error('Game not found');
     game.actions.push({ playerId, action });
     if (game.simulation) {
+        const prev = JSON.parse(JSON.stringify(game.state));
         game.state = game.simulation.runQuarter();
+        game.state.news = await llm.generateNewsUpdate(prev, game.state);
+        for (const company of game.state.companies) {
+            company.aiOpportunity = await llm.generateAIOpportunity(company);
+        }
     }
 }
 
@@ -37,7 +54,12 @@ async function saveGMAction(gameId, command) {
     if (!game) throw new Error('Game not found');
     game.actions.push({ gm: true, command });
     if (game.simulation) {
+        const prev = JSON.parse(JSON.stringify(game.state));
         game.state = game.simulation.runQuarter();
+        game.state.news = await llm.generateNewsUpdate(prev, game.state);
+        for (const company of game.state.companies) {
+            company.aiOpportunity = await llm.generateAIOpportunity(company);
+        }
     }
 }
 

--- a/backend/services/llmService.js
+++ b/backend/services/llmService.js
@@ -1,0 +1,55 @@
+const { GoogleGenerativeAI } = require('@google/generative-ai');
+
+const apiKey = process.env.GEMINI_API_KEY || '';
+const genAI = new GoogleGenerativeAI(apiKey);
+const model = genAI.getGenerativeModel({ model: 'gemini-pro' });
+
+async function callModel(prompt) {
+    const result = await model.generateContent(prompt);
+    const response = await result.response;
+    return response.text();
+}
+
+function extractJSON(text) {
+    const match = text.match(/\{[\s\S]*\}|\[[\s\S]*\]/);
+    if (match) {
+        try {
+            return JSON.parse(match[0]);
+        } catch (err) {
+            return null;
+        }
+    }
+    return null;
+}
+
+async function generateEcosystem(playerCount) {
+    const prompt = `Generate a JSON array of ${playerCount} interconnected businesses. Include a simple name and type for each business.`;
+    const text = await callModel(prompt);
+    return extractJSON(text) || [];
+}
+
+async function generateCompanyDetails(businessType) {
+    const prompt = `Create a detailed profile in JSON for a ${businessType} business. Include backstory, financials, objectives and a small employee roster.`;
+    const text = await callModel(prompt);
+    return extractJSON(text) || {};
+}
+
+async function generateAIOpportunity(business) {
+    const prompt = `Given this business profile: ${JSON.stringify(business)}, suggest one AI-driven opportunity in JSON with a title and description.`;
+    const text = await callModel(prompt);
+    return extractJSON(text) || {};
+}
+
+async function generateNewsUpdate(previousState, newState) {
+    const prompt = `Write a short news update summarizing the economic changes from ${JSON.stringify(previousState)} to ${JSON.stringify(newState)}.`;
+    const text = await callModel(prompt);
+    return text.trim();
+}
+
+module.exports = {
+    generateEcosystem,
+    generateCompanyDetails,
+    generateAIOpportunity,
+    generateNewsUpdate,
+    _test: { callModel, extractJSON }
+};

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -1,3 +1,10 @@
+jest.mock('../services/llmService', () => ({
+  generateEcosystem: jest.fn().mockResolvedValue([]),
+  generateCompanyDetails: jest.fn().mockResolvedValue({}),
+  generateAIOpportunity: jest.fn().mockResolvedValue({}),
+  generateNewsUpdate: jest.fn().mockResolvedValue('')
+}));
+
 const request = require('supertest');
 const { app, server } = require('../server');
 

--- a/backend/tests/firestoreService.test.js
+++ b/backend/tests/firestoreService.test.js
@@ -1,3 +1,10 @@
+jest.mock('../services/llmService', () => ({
+  generateEcosystem: jest.fn().mockResolvedValue([]),
+  generateCompanyDetails: jest.fn().mockResolvedValue({}),
+  generateAIOpportunity: jest.fn().mockResolvedValue({}),
+  generateNewsUpdate: jest.fn().mockResolvedValue('')
+}));
+
 const firestore = require('../services/firestoreService');
 
 describe('firestoreService', () => {

--- a/backend/tests/llmService.test.js
+++ b/backend/tests/llmService.test.js
@@ -1,0 +1,48 @@
+jest.mock('@google/generative-ai', () => {
+  const mockGenerateContent = jest.fn();
+  return {
+    GoogleGenerativeAI: jest.fn().mockImplementation(() => ({
+      getGenerativeModel: jest.fn().mockReturnValue({ generateContent: mockGenerateContent })
+    })),
+    __mockGenerateContent: mockGenerateContent
+  };
+});
+
+const { __mockGenerateContent } = require('@google/generative-ai');
+
+const llm = require('../services/llmService');
+
+beforeEach(() => {
+  __mockGenerateContent.mockReset();
+});
+
+test('generateEcosystem returns parsed JSON', async () => {
+  __mockGenerateContent.mockResolvedValue({ response: { text: () => Promise.resolve('[{"name":"Biz","type":"bakery"}]') } });
+  const result = await llm.generateEcosystem(1);
+  expect(__mockGenerateContent).toHaveBeenCalled();
+  const prompt = __mockGenerateContent.mock.calls[0][0];
+  expect(prompt).toMatch(/Generate a JSON array/);
+  expect(Array.isArray(result)).toBe(true);
+  expect(result[0].name).toBe('Biz');
+});
+
+test('generateCompanyDetails returns object', async () => {
+  __mockGenerateContent.mockResolvedValue({ response: { text: () => Promise.resolve('{"name":"TestCo"}') } });
+  const result = await llm.generateCompanyDetails('bakery');
+  expect(__mockGenerateContent).toHaveBeenCalled();
+  expect(result).toHaveProperty('name', 'TestCo');
+});
+
+test('generateAIOpportunity returns object', async () => {
+  __mockGenerateContent.mockResolvedValue({ response: { text: () => Promise.resolve('{"title":"AI"}') } });
+  const result = await llm.generateAIOpportunity({ name: 'Biz' });
+  expect(__mockGenerateContent).toHaveBeenCalled();
+  expect(result).toHaveProperty('title', 'AI');
+});
+
+test('generateNewsUpdate returns text', async () => {
+  __mockGenerateContent.mockResolvedValue({ response: { text: () => Promise.resolve('News') } });
+  const result = await llm.generateNewsUpdate({}, {});
+  expect(__mockGenerateContent).toHaveBeenCalled();
+  expect(result).toBe('News');
+});


### PR DESCRIPTION
## Summary
- add `@google/generative-ai` dependency
- create `llmService.js` for Gemini API prompts
- integrate llmService in firestore logic for company generation and news updates
- test llmService and update existing tests with mocks for Gemini calls

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_684e302de4d483239765548f593171d5